### PR TITLE
Fix unmap_memory bug

### DIFF
--- a/module/map.c
+++ b/module/map.c
@@ -85,7 +85,7 @@ struct map* map_find(const struct list* list, u64 vaddr)
 
         if (map->owner == current)
         {
-            if (map->vaddr == (vaddr & PAGE_MASK) || map->vaddr == (vaddr & GPU_PAGE_MASK))
+            if (map->vaddr == (vaddr & (~(map->page_size - 1))))
             {
                 return map;
             }


### PR DESCRIPTION
When running `./nvm-latency-bench` or other tests, the bug appears as below:
`[unmap_memory] Page unmapping kernel request failed: Invalid argument`

This is a bug mentioned in #22 

The bug appears when map A and B is created by host but when trying to unmap B
`mapA->vaddr == (vaddr & GPU_PAGE_MASK)` can also be true