### PR TITLE
CUDA memory alignment fix

### DIFF
--- a/benchmarks/cuda/buffer.cu
+++ b/benchmarks/cuda/buffer.cu
@@ -101,7 +101,7 @@ DmaPtr createDma(const nvm_ctrl_t* ctrl, size_t size, int cudaDevice)
 
     getDeviceMemory(cudaDevice, bufferPtr, devicePtr, size);
 
-    int status = nvm_dma_map_device(&dma, ctrl, devicePtr, size);
+    int status = nvm_dma_map_device(&dma, ctrl, (void *)NVM_PAGE_ALIGN((uintptr_t)devicePtr, 1UL << 16), NVM_ADDR_MASK(size, 1UL << 16));
     if (!nvm_ok(status))
     {
         cudaFree(bufferPtr);

--- a/benchmarks/cuda/main.cu
+++ b/benchmarks/cuda/main.cu
@@ -413,7 +413,7 @@ static double launchNvmKernel(const Controller& ctrl, BufferPtr destination, con
     const size_t totalChunks = settings.numChunks * settings.numThreads;
 
     // Create input buffer
-    const size_t sourceBufferSize = NVM_PAGE_ALIGN((settings.doubleBuffered + 1) * chunkSize * settings.numThreads, 1UL << 16);
+    const size_t sourceBufferSize = (settings.doubleBuffered + 1) * chunkSize * settings.numThreads + (1UL << 16);
     auto source = createDma(ctrl.ctrl, sourceBufferSize, settings.cudaDevice, settings.adapter, settings.segmentId + 1); // vaddr is a dev ptr
 
     std::shared_ptr<CmdTime> times;

--- a/benchmarks/cuda/queue.cu
+++ b/benchmarks/cuda/queue.cu
@@ -22,7 +22,7 @@ __host__ DmaPtr prepareQueuePair(QueuePair& qp, const Controller& ctrl, const Se
     size_t prpListSize = ctrl.info.page_size * settings.numThreads * (settings.doubleBuffered + 1);
 
     // qmem->vaddr will be already a device pointer after the following call
-    auto qmem = createDma(ctrl.ctrl, NVM_PAGE_ALIGN(queueMemSize + prpListSize, 1UL << 16), settings.cudaDevice, settings.adapter, settings.segmentId);
+    auto qmem = createDma(ctrl.ctrl, queueMemSize + prpListSize + (1UL << 16), settings.cudaDevice, settings.adapter, settings.segmentId);
 
     // Set members
     qp.pageSize = ctrl.info.page_size;


### PR DESCRIPTION
Cuda API nvidia_p2p_get_pages to allocate pinned physical page needs the virtual address to be aligned with 64KB boundary. So the input virtual address to nvm_dma_map_device needs to be adjusted properly to make sure both virtual address to hold submission/completion queue and the related pinned physical page could be set up properly.

Generally the change will fix below reported issues specific for "nvm-cuda-bench":
nvm-cuda-bench failed as "an illegal memory access was encountered" #32